### PR TITLE
#13 parent pom

### DIFF
--- a/KarumiAppAcceptanceTests/README.md
+++ b/KarumiAppAcceptanceTests/README.md
@@ -15,9 +15,13 @@ You can find instructions to run it in its README file
 
 You can run the whole test suite using the following command:
 
-> mvn clean install
+> mvn test
 
 Any maven build of this module will also run the whole acceptance test suite.
+Running this module automatically deploys the service from Jar file located in KarumiAppService/target/
+The build will fail if the jar is not present, but it is auto generated on building the KarumiAppService module or the parent module.
+
+
 
 ## Notes
 

--- a/KarumiAppAcceptanceTests/launchServer.sh
+++ b/KarumiAppAcceptanceTests/launchServer.sh
@@ -1,0 +1,1 @@
+java -jar ../KarumiAppService/target/karumi-app-service-0.0.1-SNAPSHOT.jar

--- a/KarumiAppAcceptanceTests/pom.xml
+++ b/KarumiAppAcceptanceTests/pom.xml
@@ -4,25 +4,25 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.orwellg</groupId>
-	<artifactId>karumi-service-acceptance</artifactId>
+	<parent>
+		<groupId>com.karumi</groupId>
+		<artifactId>karumi-service-parent</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<groupId>com.karumi</groupId>
+	<artifactId>karumi-app-acceptance-tests</artifactId>
+	<name>KarumiAppAcceptanceTests</name>
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
 		<cucumber.version>4.0.2</cucumber.version>
-		<swagger-version>2.9.2</swagger-version>
+		<main.basedir>${project.parent.basedir}</main.basedir>
 	</properties>
 
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.6.RELEASE</version>
-		<relativePath /> <!-- lookup parent from repository -->
-	</parent>
+
 
 	<dependencies>
 		<dependency>
@@ -36,6 +36,7 @@
 			<artifactId>kotlin-stdlib</artifactId>
 			<version>1.3.70</version>
 		</dependency>
+
 		<!-- Cucumber dependencies -->
 		<dependency>
 			<groupId>io.cucumber</groupId>
@@ -93,6 +94,8 @@
 			<artifactId>lombok</artifactId>
 			<optional>false</optional>
 		</dependency>
+
+
 	</dependencies>
 
 
@@ -103,10 +106,36 @@
 				<filtering>true</filtering>
 				<excludes>
 					<exclude>**/*.properties</exclude>
-					<exclude>**/*.xml</exclude>
 				</excludes>
 			</resource>
 		</resources>
+
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>3.0.0</version>
+
+				<executions>
+					<execution>
+                        <id>Launch server</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+							<async>true</async>
+							<executable>java</executable>
+							<arguments>
+								<argument> -jar </argument>
+								<argument> ${main.basedir}\KarumiAppService\target\karumi-app-service-0.0.1-SNAPSHOT.jar </argument>
+							</arguments>
+                        </configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+
 
 	</build>
 </project>

--- a/KarumiAppAcceptanceTests/src/test/java/com/karumi/client/WebClient.java
+++ b/KarumiAppAcceptanceTests/src/test/java/com/karumi/client/WebClient.java
@@ -167,9 +167,6 @@ public class WebClient {
 				.addHeader("Sec-Fetch-User", "?1")
 				.addHeader("Sec-Fetch-Dest", "document")
 				.build();
-		log.info("---------------------------------------------------");
-		log.info("Request to authenticate: ");
-		log.info(request.toString());
 		return client.newCall(request).execute();
 	}
 
@@ -192,9 +189,6 @@ public class WebClient {
 				.addHeader("Sec-Fetch-User", "?1")
 				.addHeader("Sec-Fetch-Dest", "document")
 				.build();
-		log.info("---------------------------------------------------");
-		log.info("Request to authenticate: ");
-		log.info(request.toString());
 		return client.newCall(request).execute();
 	}
 

--- a/KarumiAppAcceptanceTests/src/test/java/com/karumi/support/KarumiAppService.java
+++ b/KarumiAppAcceptanceTests/src/test/java/com/karumi/support/KarumiAppService.java
@@ -32,7 +32,6 @@ public class KarumiAppService {
 
     public void getLanding() throws IOException {
         if(navigationWorld.getSessionCookie().isPresent()){
-            log.info("getting landing  page with cookie");
             navigationWorld.setLastGetPageResponse(webClient.getMainPage(navigationWorld.getSessionCookie().get()));
         }else{
             navigationWorld.setLastGetPageResponse(webClient.getMainPage());

--- a/KarumiAppAcceptanceTests/src/test/java/com/karumi/support/NavigationWorld.java
+++ b/KarumiAppAcceptanceTests/src/test/java/com/karumi/support/NavigationWorld.java
@@ -38,7 +38,6 @@ public class NavigationWorld {
     private Response lastAuthenticateResponse;
 
     public Optional<Cookie> getSessionCookie(){
-        log.info("Returning session id for call: " + lastSessionId);
         if(lastSessionId != null){
             return Optional.of(new Cookie.Builder("JSESSIONID", lastSessionId).build());
         }
@@ -48,12 +47,10 @@ public class NavigationWorld {
 
     public void updateSessionId(Response response) {
         String setCookieHeader = response.headers().get("Set-Cookie");
-        log.info("Updating cookie header with: " + setCookieHeader);
         if(setCookieHeader != null) {
            Arrays.stream(setCookieHeader.split(";"))
             .filter(s -> s.contains("JSESSIONID")).findAny().ifPresent(this::setLastSessionId);
            this.lastSessionId = lastSessionId.replace("JSESSIONID=", "");
-           log.info("New cookie id: " + lastSessionId);
         }
     }
 

--- a/KarumiAppService/pom.xml
+++ b/KarumiAppService/pom.xml
@@ -6,18 +6,19 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>2.2.6.RELEASE</version>
-		<relativePath />
 	</parent>
-	<artifactId>KarumiAppService</artifactId>
+
+	<artifactId>karumi-app-service</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>KarumiAppService</name>
-	<description>Demo project for Karumi job application</description>
+	<description>Demo project for Karumi application</description>
+    <name>KarumiAppService</name>
 
 	<properties>
 		<java.version>1.8</java.version>
 	</properties>
 
 	<dependencies>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>

--- a/README.md
+++ b/README.md
@@ -1,14 +1,37 @@
 # KarumiApp
 
 This is a coding challenge application for Karumi. Everything you can find here is a mockup of a real project.
-You are seeing the documentation for the whole project.
+You are seeing the documentation for the parent module.
 
-This folder contains two projects:
-    - KarumiAppAcceptanceTests: The acceptance tests for the Karumi App service.
-    - KarumiAppService: The actual code and business logic for the Karumi App.
+This folder contains two child modules:
+
+    KarumiAppAcceptanceTests: The acceptance tests for the Karumi App service.
+   
+    KarumiAppService: The actual code and business logic for the Karumi App.
 
 
 Documentation for each of those can be found in their respective README files.
+
+## Building the module
+
+To build the project, run
+
+>mvn clean install
+
+You can find the instructions for installing Maven in the official page: https://maven.apache.org/
+
+
+Building this parent module will trigger the following steps:
+
+- Build the KarumiAppService child module, generating an executable Jar file.
+- Build the KarumiAppAcceptanceTests child module, running the automated tests agains that Jar file
+ 
+## Running the application
+
+   In order to run the application, simply run the jar file generated in KarumiAppService/target
+   This file is generated on building this parent module or the KarumiAppService module.
+   
+   You can find more details, including credentials, in KarumiAppService/README.md
 
 ## Notes:
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.karumi</groupId>
+	<artifactId>karumi-service-parent</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<java.version>1.8</java.version>
+		<cucumber.version>4.0.2</cucumber.version>
+		<main.basedir>${project.basedir}</main.basedir>
+		<swagger-version>2.9.2</swagger-version>
+	</properties>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.2.6.RELEASE</version>
+	</parent>
+
+  <modules>
+      <module>KarumiAppService</module>
+	  <module>KarumiAppAcceptanceTests</module>
+  </modules>
+
+  <build>
+
+      <plugins>
+          <plugin>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-maven-plugin</artifactId>
+              <configuration>
+                  <skip>true</skip>
+              </configuration>
+          </plugin>
+      </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Added parent pom and proper deployment of the service on the acceptance tests.
Minor fixes to the poms and update README file to reflect these changes.

The deployment of the service is done in a simple way, directly calling the generated jar.
Ideally, this would actually use the maven exec plugin instead, but it is not required, the end functionality is almost the same.
It would retrieve the artifact from the local repository, but we don't care about artifacts in the repository, only the latest one generated by the service module.

An improvement that should be done on this is to have a variable for the version of the jar, instead of a hardcoded "-0.0.1-SNAPSHOT"